### PR TITLE
Refactoring Soundcloud data access methods to a different class

### DIFF
--- a/SCloudRandomizer.xcodeproj/project.pbxproj
+++ b/SCloudRandomizer.xcodeproj/project.pbxproj
@@ -29,8 +29,10 @@
 		19F38A641A9F811C002361E6 /* TrackInfoVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 19F38A631A9F811C002361E6 /* TrackInfoVC.m */; };
 		4E3A92771AE0602C00640EFB /* play.png in Resources */ = {isa = PBXBuildFile; fileRef = 4E3A92761AE0602C00640EFB /* play.png */; };
 		4E3A92791AE0604800640EFB /* tag.png in Resources */ = {isa = PBXBuildFile; fileRef = 4E3A92781AE0604800640EFB /* tag.png */; };
+		4E8AC8DD1AF2C69900B2054B /* Utility.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E8AC8DC1AF2C69900B2054B /* Utility.m */; };
 		4ED3F5A31AB272A200259C84 /* background.png in Resources */ = {isa = PBXBuildFile; fileRef = 4ED3F5A21AB272A200259C84 /* background.png */; };
 		4ED7E8531AF17A9600F2D38E /* MusicSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E8521AF17A9600F2D38E /* MusicSource.m */; };
+		4ED7E8561AF1DFDA00F2D38E /* Track.m in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E8551AF1DFDA00F2D38E /* Track.m */; };
 		C14EEDFE7A11E93DCFB9D4D8 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EC7B3A8D657E6F7F5BDB2255 /* libPods.a */; };
 /* End PBXBuildFile section */
 
@@ -93,9 +95,13 @@
 		276CF3AB99530D51BD666B04 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		4E3A92761AE0602C00640EFB /* play.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = play.png; sourceTree = "<group>"; };
 		4E3A92781AE0604800640EFB /* tag.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tag.png; sourceTree = "<group>"; };
+		4E8AC8DB1AF2C68A00B2054B /* Utility.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Utility.h; sourceTree = "<group>"; };
+		4E8AC8DC1AF2C69900B2054B /* Utility.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Utility.m; sourceTree = "<group>"; };
 		4ED3F5A21AB272A200259C84 /* background.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = background.png; sourceTree = "<group>"; };
 		4ED7E84A1AF16C4800F2D38E /* MusicSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MusicSource.h; sourceTree = "<group>"; };
 		4ED7E8521AF17A9600F2D38E /* MusicSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MusicSource.m; sourceTree = "<group>"; };
+		4ED7E8541AF1DFC800F2D38E /* Track.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Track.h; sourceTree = "<group>"; };
+		4ED7E8551AF1DFDA00F2D38E /* Track.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Track.m; sourceTree = "<group>"; };
 		E232F970F295066B5DBC30F0 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		EC7B3A8D657E6F7F5BDB2255 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -190,6 +196,10 @@
 				1913B8661AE0027F007D2C0E /* MainVCDelegate.h */,
 				4ED7E84A1AF16C4800F2D38E /* MusicSource.h */,
 				4ED7E8521AF17A9600F2D38E /* MusicSource.m */,
+				4ED7E8541AF1DFC800F2D38E /* Track.h */,
+				4ED7E8551AF1DFDA00F2D38E /* Track.m */,
+				4E8AC8DB1AF2C68A00B2054B /* Utility.h */,
+				4E8AC8DC1AF2C69900B2054B /* Utility.m */,
 			);
 			path = SCloudRandomizer;
 			sourceTree = "<group>";
@@ -385,9 +395,11 @@
 				1997F7361A6421C700109F76 /* GlobalData.m in Sources */,
 				1997F7331A64211700109F76 /* SearchParamsVC.m in Sources */,
 				19F38A641A9F811C002361E6 /* TrackInfoVC.m in Sources */,
+				4ED7E8561AF1DFDA00F2D38E /* Track.m in Sources */,
 				1997F7391A6454DC00109F76 /* SearchParams.m in Sources */,
 				19CDED2F1A2FB92100DD97CC /* SCloudRandomizer.xcdatamodeld in Sources */,
 				19CDED2C1A2FB92100DD97CC /* AppDelegate.m in Sources */,
+				4E8AC8DD1AF2C69900B2054B /* Utility.m in Sources */,
 				4ED7E8531AF17A9600F2D38E /* MusicSource.m in Sources */,
 				19C18F0D1A30CF2E00281221 /* MainViewController.m in Sources */,
 				19CDED291A2FB92100DD97CC /* main.m in Sources */,

--- a/SCloudRandomizer.xcodeproj/project.pbxproj
+++ b/SCloudRandomizer.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		4E3A92771AE0602C00640EFB /* play.png in Resources */ = {isa = PBXBuildFile; fileRef = 4E3A92761AE0602C00640EFB /* play.png */; };
 		4E3A92791AE0604800640EFB /* tag.png in Resources */ = {isa = PBXBuildFile; fileRef = 4E3A92781AE0604800640EFB /* tag.png */; };
 		4ED3F5A31AB272A200259C84 /* background.png in Resources */ = {isa = PBXBuildFile; fileRef = 4ED3F5A21AB272A200259C84 /* background.png */; };
+		4ED7E8531AF17A9600F2D38E /* MusicSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 4ED7E8521AF17A9600F2D38E /* MusicSource.m */; };
 		C14EEDFE7A11E93DCFB9D4D8 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EC7B3A8D657E6F7F5BDB2255 /* libPods.a */; };
 /* End PBXBuildFile section */
 
@@ -93,6 +94,8 @@
 		4E3A92761AE0602C00640EFB /* play.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = play.png; sourceTree = "<group>"; };
 		4E3A92781AE0604800640EFB /* tag.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tag.png; sourceTree = "<group>"; };
 		4ED3F5A21AB272A200259C84 /* background.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = background.png; sourceTree = "<group>"; };
+		4ED7E84A1AF16C4800F2D38E /* MusicSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MusicSource.h; sourceTree = "<group>"; };
+		4ED7E8521AF17A9600F2D38E /* MusicSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MusicSource.m; sourceTree = "<group>"; };
 		E232F970F295066B5DBC30F0 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		EC7B3A8D657E6F7F5BDB2255 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -185,6 +188,8 @@
 				19F38A621A9F811C002361E6 /* TrackInfoVC.h */,
 				19F38A631A9F811C002361E6 /* TrackInfoVC.m */,
 				1913B8661AE0027F007D2C0E /* MainVCDelegate.h */,
+				4ED7E84A1AF16C4800F2D38E /* MusicSource.h */,
+				4ED7E8521AF17A9600F2D38E /* MusicSource.m */,
 			);
 			path = SCloudRandomizer;
 			sourceTree = "<group>";
@@ -383,6 +388,7 @@
 				1997F7391A6454DC00109F76 /* SearchParams.m in Sources */,
 				19CDED2F1A2FB92100DD97CC /* SCloudRandomizer.xcdatamodeld in Sources */,
 				19CDED2C1A2FB92100DD97CC /* AppDelegate.m in Sources */,
+				4ED7E8531AF17A9600F2D38E /* MusicSource.m in Sources */,
 				19C18F0D1A30CF2E00281221 /* MainViewController.m in Sources */,
 				19CDED291A2FB92100DD97CC /* main.m in Sources */,
 			);

--- a/SCloudRandomizer/Base.lproj/Main.storyboard
+++ b/SCloudRandomizer/Base.lproj/Main.storyboard
@@ -80,7 +80,7 @@
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
-                                    <action selector="toggleFavState:" destination="AGx-bt-YRN" eventType="touchUpInside" id="yvC-qr-WYZ"/>
+                                    <action selector="updateFavState:" destination="AGx-bt-YRN" eventType="touchUpInside" id="aQr-Fq-vZe"/>
                                 </connections>
                             </button>
                             <button hidden="YES" opaque="NO" alpha="0.69999999999999996" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoLight" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VQ1-zg-oUh" userLabel="InfoButton">

--- a/SCloudRandomizer/Base.lproj/Main.storyboard
+++ b/SCloudRandomizer/Base.lproj/Main.storyboard
@@ -80,7 +80,7 @@
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
-                                    <action selector="updateFavState:" destination="AGx-bt-YRN" eventType="touchUpInside" id="aQr-Fq-vZe"/>
+                                    <action selector="setFavState:" destination="AGx-bt-YRN" eventType="touchUpInside" id="zze-GL-aBg"/>
                                 </connections>
                             </button>
                             <button hidden="YES" opaque="NO" alpha="0.69999999999999996" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoLight" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VQ1-zg-oUh" userLabel="InfoButton">

--- a/SCloudRandomizer/Base.lproj/Main.storyboard
+++ b/SCloudRandomizer/Base.lproj/Main.storyboard
@@ -80,7 +80,7 @@
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
-                                    <action selector="updateFavState:" destination="AGx-bt-YRN" eventType="touchUpInside" id="y6W-zK-2zP"/>
+                                    <action selector="toggleFavState:" destination="AGx-bt-YRN" eventType="touchUpInside" id="yvC-qr-WYZ"/>
                                 </connections>
                             </button>
                             <button hidden="YES" opaque="NO" alpha="0.69999999999999996" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoLight" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VQ1-zg-oUh" userLabel="InfoButton">

--- a/SCloudRandomizer/Base.lproj/MusicSource.m
+++ b/SCloudRandomizer/Base.lproj/MusicSource.m
@@ -1,9 +1,0 @@
-//
-//  MusicSource.m
-//  SCloudRandomizer
-//
-//  Created by Asha Balasubramaniam on 4/29/15.
-//  Copyright (c) 2015 Akshay Bharath. All rights reserved.
-//
-
-#import <Foundation/Foundation.h>

--- a/SCloudRandomizer/Base.lproj/MusicSource.m
+++ b/SCloudRandomizer/Base.lproj/MusicSource.m
@@ -1,0 +1,9 @@
+//
+//  MusicSource.m
+//  SCloudRandomizer
+//
+//  Created by Asha Balasubramaniam on 4/29/15.
+//  Copyright (c) 2015 Akshay Bharath. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>

--- a/SCloudRandomizer/GlobalData.h
+++ b/SCloudRandomizer/GlobalData.h
@@ -20,7 +20,4 @@
 // Singleton method
 + (GlobalData *)getInstance;
 
-// Check if string is null or empty
-+ (BOOL)stringIsNilOrEmpty:(NSString*)aString;
-
 @end

--- a/SCloudRandomizer/GlobalData.m
+++ b/SCloudRandomizer/GlobalData.m
@@ -26,10 +26,5 @@ static GlobalData *instance;
     return instance;
 }
 
-+ (BOOL)stringIsNilOrEmpty:(NSString*)aString
-{
-    return !(aString && aString.length);
-}
-
 
 @end

--- a/SCloudRandomizer/MainVCDelegate.h
+++ b/SCloudRandomizer/MainVCDelegate.h
@@ -7,6 +7,7 @@
 //
 
 #import "SearchParams.h"
+@class Track;
 
 #ifndef SCloudRandomizer_MainVCDelegate_h
 #define SCloudRandomizer_MainVCDelegate_h
@@ -14,7 +15,7 @@
 // Protocol definition
 @protocol MainVCDelegate<NSObject>
 
-- (NSDictionary *)getCurrentTrack;
+- (Track *)getCurrentTrack;
 - (SearchParams *)getCurrentSearchParams;
 
 @end

--- a/SCloudRandomizer/MainViewController.h
+++ b/SCloudRandomizer/MainViewController.h
@@ -56,7 +56,7 @@ typedef NSUInteger PlayerState;
 - (IBAction)playSong:(id)sender;
 - (IBAction)playNext:(id)sender;
 - (IBAction)changeParams:(id)sender;
-- (IBAction)toggleFavState:(id)sender;
+- (IBAction)updateFavState:(id)sender;
 - (IBAction)showTrackInfo:(id)sender;
 
 @end

--- a/SCloudRandomizer/MainViewController.h
+++ b/SCloudRandomizer/MainViewController.h
@@ -15,6 +15,7 @@
 #import "GlobalData.h"
 #import "SearchParams.h"
 #import "TrackInfoVC.h"
+#import "MusicSource.h"
 
 @interface MainViewController : UIViewController<AVAudioPlayerDelegate, MainVCDelegate>
 
@@ -55,8 +56,7 @@ typedef NSUInteger PlayerState;
 - (IBAction)playSong:(id)sender;
 - (IBAction)playNext:(id)sender;
 - (IBAction)changeParams:(id)sender;
-- (IBAction)updateFavState:(id)sender;
+- (IBAction)toggleFavState:(id)sender;
 - (IBAction)showTrackInfo:(id)sender;
-- (BOOL)isPlayerLoggedIn;
 
 @end

--- a/SCloudRandomizer/MainViewController.h
+++ b/SCloudRandomizer/MainViewController.h
@@ -56,7 +56,7 @@ typedef NSUInteger PlayerState;
 - (IBAction)playSong:(id)sender;
 - (IBAction)playNext:(id)sender;
 - (IBAction)changeParams:(id)sender;
-- (IBAction)updateFavState:(id)sender;
+- (IBAction)setFavState:(id)sender;
 - (IBAction)showTrackInfo:(id)sender;
 
 @end

--- a/SCloudRandomizer/MainViewController.m
+++ b/SCloudRandomizer/MainViewController.m
@@ -7,26 +7,30 @@
 //
 
 #import "MainViewController.h"
+#import "Utility.h"
+#import "Track.h"
 
 const double LoggedOutBackgroundImage_Opacity = 0.7;
+const double LoggedInBackgroundImage_Opacity = 0.2;
 
+// Private declarations
 @interface MainViewController ()
 
-// Private properties
-@property (strong, nonatomic) NSData *currentSongData;
+typedef void(^singleTrackDownloaded)(NSData* trackData);
+
 @property BOOL isCurrentSongLiked;
 @property NSUInteger currentSongNumber;
-@property (strong, nonatomic) NSDictionary *currentTrack;
+@property (strong, nonatomic) Track *currentTrack;
 @property (strong, nonatomic) SearchParams *searchParams;
 @property MusicSource *musicSource;
+
+- (void)getNextTrack:(singleTrackDownloaded)completionHandler;
 
 @end
 
 @implementation MainViewController
 
-
-- (void)viewDidLoad
-{
+- (void)viewDidLoad {
     [super viewDidLoad];
     
     self.musicSource = [MusicSource getInstance];
@@ -57,25 +61,27 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
     self.paramsChanged = YES;
 }
 
-- (void)viewWillAppear:(BOOL)animated
-{
+- (void) initPlayer:(NSData*) trackData {
+    self.player = [[AVAudioPlayer alloc] initWithData:trackData error:nil];
+    self.player.delegate = self;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     
-    if ([self.musicSource isUserLoggedIn])
-    {
+    if ([self.musicSource isUserLoggedIn]) {
         [self.btnSCConnect setHidden:YES];
         [self.btnSCDisconnect setHidden:NO];
-        self.backgroundImage.alpha = 0.2;
+        self.backgroundImage.alpha = LoggedInBackgroundImage_Opacity;
         
-        if (self.searchParams.hasChanged)
-        {
-            if ([self.player isPlaying])
-            {
-                [self doPlayNextSong];
+        if (self.searchParams.hasChanged) {
+            if ([self.player isPlaying]) {
+                [self playNextTrack];
             }
-            else
-            {
-                [self getTracks:YES shouldPlay:NO];
+            else {
+                [self getNextTrack:^(NSData* trackData) {
+                    [self initPlayer:trackData];
+                }];
             }
             
             self.searchParams.hasChanged = NO;
@@ -87,15 +93,13 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
     }
 }
 
-- (void)viewWillDisappear:(BOOL)animated
-{
+- (void)viewWillDisappear:(BOOL)animated {
     [super viewWillDisappear:animated];
     [[UIApplication sharedApplication] endReceivingRemoteControlEvents];
     [self resignFirstResponder];
 }
 
-- (void)viewDidAppear:(BOOL)animated
-{
+- (void)viewDidAppear:(BOOL)animated {
     [super viewDidAppear:animated];
     
     //Once the view has loaded then we can register to begin recieving controls and we can become the first responder
@@ -103,14 +107,12 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
     [self becomeFirstResponder];
 }
 
-- (void)didReceiveMemoryWarning
-{
+- (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
 }
 
-- (IBAction)logout:(id)sender
-{
+- (IBAction)logout:(id)sender {
     [self.musicSource logout];
     
     [self.player stop];
@@ -135,8 +137,7 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
 }
 
 // ToDo - Move this into a login view
-- (IBAction)login:(id)sender
-{
+- (IBAction)login:(id)sender {
     [SCSoundCloud requestAccessWithPreparedAuthorizationURLHandler:^(NSURL *preparedURL){
         SCLoginViewController *loginViewController = [SCLoginViewController loginViewControllerWithPreparedURL:preparedURL
                                   completionHandler:^(NSError *error) {
@@ -153,40 +154,32 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
     }];
 }
 
-- (IBAction)playSong:(id)sender
-{
+- (IBAction)playSong:(id)sender {
     [self playPauseSong];
 }
 
-- (IBAction)playNext:(id)sender
-{
-    [self doPlayNextSong];
+- (IBAction)playNext:(id)sender {
+    [self playNextTrack];
 }
 
-- (IBAction)changeParams:(id)sender
-{
+- (IBAction)changeParams:(id)sender {
     [self presentViewController:self.searchParamsVC animated:YES completion:nil];
 }
 
-- (IBAction)toggleFavState:(id)sender
-{
+- (IBAction)updateFavState:(id)sender {
     self.isCurrentSongLiked = !self.isCurrentSongLiked;
     
-    [self.musicSource updateLikeState:self.isCurrentSongLiked
-                               trackId:[[self.currentTrack objectForKey:@"id"] stringValue]];
+    [self.musicSource updateLikeState:self.isCurrentSongLiked trackId:self.currentTrack.Id];
     
-    if (self.isCurrentSongLiked)
-    {
+    if (self.isCurrentSongLiked) {
         [self.btnLike setImage:[UIImage imageNamed:@"Heart-red-transparent.png"] forState:UIControlStateNormal];
     }
-    else
-    {
+    else {
         [self.btnLike setImage:[UIImage imageNamed:@"Heart-white-transparent.png"] forState:UIControlStateNormal];
     }
 }
 
-- (IBAction)showTrackInfo:(id)sender
-{
+- (IBAction)showTrackInfo:(id)sender {
     // Custom animation
     CATransition *animation = [CATransition animation];
     animation.duration = 0.3;
@@ -197,32 +190,24 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
     [self presentViewController:self.trackInfoVC animated:NO completion:nil];
 }
 
-- (BOOL)canBecomeFirstResponder
-{
+- (BOOL)canBecomeFirstResponder {
     return YES;
 }
 
-- (void)playPauseSong
-{
-    if (![self.player isPlaying])
-    {
-        if (self.player.data == nil && self.currentSongData == nil)
-        {
-            NSDictionary *track = [self.tracks objectAtIndex:1];
-            self.currentSongNumber = 1;
-            [self getTrackInfo:track shouldPlay:YES];
-            NSLog(@"Playing song for first time");
-        }
-        else
-        {
-            [self.player prepareToPlay];
-            [self.player play];
-            [self.btnPlay setImage:[UIImage imageNamed:@"pause_btn.png"] forState:UIControlStateNormal];
+- (void)playPauseSong {
+    if (![self.player isPlaying]) {
+        if (self.player.data == nil) {
+            [self getNextTrack:^(NSData* trackData) {
+                [self initPlayer:trackData];
+                [self playNextTrack];
+                NSLog(@"Playing song for first time");
+            }];
+        } else {
+            [self playTrack];
             NSLog(@"Resuming song");
         }
     }
-    else
-    {
+    else {
         [self.btnPlay setImage:[UIImage imageNamed:@"play_btn.png"] forState:UIControlStateNormal];
         [self.player pause];
         NSLog(@"Pausing song");
@@ -231,8 +216,7 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
 
 - (MBProgressHUD*) getProgressBar:(MBProgressHUDMode)progressHudMode
                                 progressHudLabel:(NSString*) progressHudTitle
-                                progressHudDetailsLabel:(NSString*) progressHudDetails
-{
+                                progressHudDetailsLabel:(NSString*) progressHudDetails {
     MBProgressHUD* progressHud = [MBProgressHUD showHUDAddedTo:self.view animated:YES];
     progressHud.mode = progressHudMode;
     progressHud.labelText =  progressHudTitle;
@@ -240,9 +224,7 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
     return progressHud;
 }
 
-- (void)getTracks:(BOOL)shouldGetTrackInfo shouldPlay:(BOOL)playBool
-{
-    // Disable buttons
+- (void)getNextTrack:(singleTrackDownloaded)completionHandler {
     self.imgArtwork.alpha = 0.5;
     [self.btnPlay setHidden:NO];
     [self.btnNext setHidden:NO];
@@ -253,102 +235,54 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
     [self.btnChangeParams setEnabled:NO];
     
     MBProgressHUD* progressHud = [self getProgressBar:MBProgressHUDModeIndeterminate
-          progressHudLabel:@"Refreshing Track List"
+          progressHudLabel:@"Loading next track"
           progressHudDetailsLabel:@"Please wait.."];
     
-    [self.musicSource getRandomTrack:self.searchParams.keywords completionHandler:^(NSDictionary* track) {
-        [self getTrackInfo:track shouldPlay:playBool];
-        [progressHud hide:YES];
+    [self.musicSource getRandomTrack:self.searchParams.keywords
+                        completionHandler:^(Track *track) {
+                            self.currentTrack = track;
+                            [self setupLockScreenInfo:track];
+                            [self setupUI:track];
+                            [self setFavState:track];
+                            [self downloadTrack:track progressHud:progressHud completionHandler: completionHandler];
     }];
 }
 
-// Display the track info and play song if needed
-- (void)getTrackInfo:(NSDictionary *)track shouldPlay:(BOOL)play
-{
-    NSString *streamURL = [track objectForKey:@"stream_url"];
-    NSLog(@"The streamURL is: %@", streamURL);
-    
-    // Get new track if stream URL is nil
-    while ([GlobalData stringIsNilOrEmpty:streamURL])
-    {
-        NSLog(@"streamURL is null");
-        [self getTracks:NO shouldPlay:NO];
-        NSDictionary *track2 = [self.tracks objectAtIndex:self.currentSongNumber];
-        streamURL = [track2 objectForKey:@"stream_url"];
-    }
-    
-    MBProgressHUD* progressHud = [self getProgressBar:MBProgressHUDModeIndeterminate
-                            progressHudLabel:@"Loading Track"
-                            progressHudDetailsLabel:@"Please wait.."];
-    
-    SCRequestSendingProgressHandler progressHandler =
-        ^(unsigned long long bytesSent, unsigned long long bytesTotal)
-         {
-                progressHud.progress = ((float)bytesSent / bytesTotal);
-         };
-    
-    SCRequestResponseHandler responseHandler =
-        ^(NSURLResponse *response, NSData *data, NSError *error)
-        {
-                self.currentSongData = data;
-                self.player = [[AVAudioPlayer alloc] initWithData:data error:nil];
-                self.player.delegate = self;
-                
-                [self setupLockScreenInfo:track];
-                [self setupUI:track];
-                [self checkFavouritesList];
-                
-                if (play)
-                {
-                    [self.player prepareToPlay];
-                    [self.player play];
-                    [self.btnPlay setImage:[UIImage imageNamed:@"pause_btn.png"] forState:UIControlStateNormal];
-                }
-                
-                [progressHud hide:YES];
-        };
-    
-    [SCRequest performMethod:SCRequestMethodGET
-                  onResource:[NSURL URLWithString:streamURL]
-             usingParameters:nil
-                 withAccount:[SCSoundCloud account]
-      sendingProgressHandler:progressHandler
-             responseHandler:responseHandler];
+- (void)playTrack {
+    [self.player prepareToPlay];
+    [self.player play];
+    [self.btnPlay setImage:[UIImage imageNamed:@"pause_btn.png"] forState:UIControlStateNormal];
 }
 
-// Actually play the next sont
-- (void)doPlayNextSong
-{
+- (void)stopPlayingTrack {
     [self.player stop];
-    [self getTracks:YES shouldPlay:YES];
+}
+
+- (void)downloadTrack:(Track *)track
+        progressHud: (MBProgressHUD *) progressHud
+        completionHandler:(singleTrackDownloaded)completionHandler {
+    NSLog(@"The streamURL is: %@", track.streamUrl);
     
-    NSLog(@"Will play next song");
+    [track download:^(NSData* trackData) {
+        [progressHud hide:YES];
+        completionHandler(trackData);
+    }];
 }
 
-// Convert to ms
-- (NSString *)convertFromMilliseconds:(long)duration
+- (void)playNextTrack
 {
-    NSInteger minutes = floor(duration / 60000);
-    NSInteger seconds = ((duration % 60000) / 1000);
-    NSString *formatted = nil;
-    if (seconds < 10)
-    {
-        formatted = [NSString stringWithFormat:@"%ld:0%ld", (long)minutes, (long)seconds];
-    }
-    else
-    {
-        formatted = [NSString stringWithFormat:@"%ld:%ld", (long)minutes, (long)seconds];
-    }
-
-    return  formatted;
+    [self stopPlayingTrack];
+    [self getNextTrack: ^(NSData* trackData) {
+        [self initPlayer:trackData];
+        [self playTrack];
+        NSLog(@"Will play next song");
+    }];
 }
 
-// Set the like button accordingly
-- (void)checkFavouritesList
+- (void)setFavState: (Track*) track
 {
-    NSNumber *favValue = [self.currentTrack objectForKey:@"user_favorite"];
-    NSLog(@"Fav value: %@", favValue);
-    if ([favValue isEqual:@0])
+    NSLog(@"Fav value: %@", track.isLiked);
+    if (!track.isLiked)
     {
         self.isCurrentSongLiked = NO;
         [self.btnLike setImage:[UIImage imageNamed:@"Heart-white-transparent.png"] forState:UIControlStateNormal];
@@ -360,46 +294,26 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
     }
 }
 
-// Play next song as the current song is finishing
-- (void)audioPlayerDidFinishPlaying:(AVAudioPlayer *)player successfully:(BOOL)flag
-{
-    [self doPlayNextSong];
+- (void)audioPlayerDidFinishPlaying:(AVAudioPlayer *)player successfully:(BOOL)flag {
+    [self playNextTrack];
 }
 
-// Set up the lock screen
-- (void)setupLockScreenInfo:(NSDictionary *)track
-{
-    NSString *trackTitle = [track objectForKey:@"title"];
-    NSString *trackArtist = [[track objectForKey:@"user"] objectForKey:@"username"];
-    long duration = [[track objectForKey:@"duration"] longValue];
-    NSNumber *actualDuration = [NSNumber numberWithInt:(int)(duration/1000)];
-    NSString *urlString = nil;
-
-    id albumArt = [track objectForKey:@"artwork_url"];
-    if (albumArt == [NSNull null])
-    {
-        urlString = [[[track objectForKey:@"user"] objectForKey:@"avatar_url"] stringByReplacingOccurrencesOfString:@"-large" withString:@"-t300x300"];
-    }
-    else
-    {
-        urlString = [(NSString *)albumArt stringByReplacingOccurrencesOfString:@"-large" withString:@"-t300x300"];
-    }
-    
-    NSURL *imgUrl = [NSURL URLWithString:urlString];
+- (void)setupLockScreenInfo:(Track*)track {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-        NSData *imageData = [NSData dataWithContentsOfURL:imgUrl];
-        MPMediaItemArtwork *albumArtwork;
-        if (!imageData)
-        {
+        
+        NSNumber *songDurationInSeconds = [NSNumber numberWithInt:(int)(track.duration / 1000)];
+        
+        NSData *albumArtData = [NSData dataWithContentsOfURL:track.albumArtUrl];
+        MPMediaItemArtwork *albumArtwork = nil;
+        if (!albumArtData) {
             albumArtwork = [[MPMediaItemArtwork alloc] initWithImage:[UIImage imageNamed:@"Music-icon.png"]];
         }
-        else
-        {
-            albumArtwork = [[MPMediaItemArtwork alloc] initWithImage:[UIImage imageWithData:imageData]];
+        else {
+            albumArtwork = [[MPMediaItemArtwork alloc] initWithImage:[UIImage imageWithData:albumArtData]];
         }
         
         NSArray *keys = [NSArray arrayWithObjects:MPMediaItemPropertyArtist, MPMediaItemPropertyTitle, MPMediaItemPropertyArtwork, MPMediaItemPropertyPlaybackDuration, MPNowPlayingInfoPropertyPlaybackRate, nil];
-        NSArray *values = [NSArray arrayWithObjects:trackArtist, trackTitle, albumArtwork, actualDuration, [NSNumber numberWithInt:1], nil];
+        NSArray *values = [NSArray arrayWithObjects:track.artist, track.title, albumArtwork, songDurationInSeconds, [NSNumber numberWithInt:1], nil];
         NSDictionary *mediaInfo = [NSDictionary dictionaryWithObjects:values forKeys:keys];
         
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -409,8 +323,7 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
 }
 
 // Set the UI after getting track info
-- (void)setupUI:(NSDictionary *)track
-{
+- (void)setupUI:(Track *)track {
     [self.btnInfo setHidden:NO];
     [self.btnLike setHidden:NO];
     [self.btnNext setEnabled:YES];
@@ -428,33 +341,19 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
     [self.lblArtist setHidden:NO];
     [self.lblLength setHidden:NO];
     
-    long duration = [[track objectForKey:@"duration"] longValue];
-    [self.lblLengthValue setText:[self convertFromMilliseconds:duration]];
-    [self.lblArtistValue setText:[[track objectForKey:@"user"] objectForKey:@"username"]];
-    [self.lblTitleValue setText:[track objectForKey:@"title"]];
-    self.currentTrack = track;
+    [self.lblLengthValue setText:[Utility convertFromMilliseconds:track.duration]];
+    [self.lblArtistValue setText:track.artist];
+    [self.lblTitleValue setText:track.title];
+    
     self.imgArtwork.layer.borderWidth = 1;
     self.imgArtwork.alpha = 1.0;
     self.btnChangeParams.layer.borderColor = [UIColor blackColor].CGColor;
     
-    NSString *urlString = nil;
-    id albumArt = [track objectForKey:@"artwork_url"];
-    if (albumArt == [NSNull null])
-    {
-        urlString = [[[track objectForKey:@"user"] objectForKey:@"avatar_url"] stringByReplacingOccurrencesOfString:@"-large" withString:@"-t300x300"];
-    }
-    else
-    {
-        urlString = [(NSString *)albumArt stringByReplacingOccurrencesOfString:@"-large" withString:@"-t300x300"];
-    }
-    
-    NSURL *imgUrl = [NSURL URLWithString:urlString];
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-        NSData *imageData = [NSData dataWithContentsOfURL:imgUrl];
+        NSData *albumArtData = [NSData dataWithContentsOfURL:track.albumArtUrl];
         
         dispatch_async(dispatch_get_main_queue(), ^{
-            // Update the UI
-            self.imgArtwork.image = [UIImage imageWithData:imageData];
+            self.imgArtwork.image = [UIImage imageWithData:albumArtData];
         });
     });
 }
@@ -473,14 +372,14 @@ const double LoggedOutBackgroundImage_Opacity = 0.7;
         }
         else if (event.subtype == UIEventSubtypeRemoteControlNextTrack)
         {
-            [self doPlayNextSong];
+            [self playNextTrack];
         }
     }
 }
 
 // MainVCDelegate method
 // Return current track
-- (NSDictionary *)getCurrentTrack
+- (Track *)getCurrentTrack
 {
     return self.currentTrack;
 }

--- a/SCloudRandomizer/MainViewController.m
+++ b/SCloudRandomizer/MainViewController.m
@@ -10,8 +10,8 @@
 #import "Utility.h"
 #import "Track.h"
 
-const double LoggedOutBackgroundImage_Opacity = 0.7;
-const double LoggedInBackgroundImage_Opacity = 0.2;
+static const double LoggedOutBackgroundImageOpacity = 0.7;
+static const double LoggedInBackgroundImageOpacity = 0.2;
 
 // Private declarations
 @interface MainViewController ()
@@ -23,8 +23,6 @@ typedef void(^singleTrackDownloaded)(NSData* trackData);
 @property (strong, nonatomic) Track *currentTrack;
 @property (strong, nonatomic) SearchParams *searchParams;
 @property MusicSource *musicSource;
-
-- (void)getNextTrack:(singleTrackDownloaded)completionHandler;
 
 @end
 
@@ -72,7 +70,7 @@ typedef void(^singleTrackDownloaded)(NSData* trackData);
     if ([self.musicSource isUserLoggedIn]) {
         [self.btnSCConnect setHidden:YES];
         [self.btnSCDisconnect setHidden:NO];
-        self.backgroundImage.alpha = LoggedInBackgroundImage_Opacity;
+        self.backgroundImage.alpha = LoggedInBackgroundImageOpacity;
         
         if (self.searchParams.hasChanged) {
             if ([self.player isPlaying]) {
@@ -89,7 +87,7 @@ typedef void(^singleTrackDownloaded)(NSData* trackData);
     }
     else
     {
-        self.backgroundImage.alpha = LoggedOutBackgroundImage_Opacity;
+        self.backgroundImage.alpha = LoggedOutBackgroundImageOpacity;
     }
 }
 
@@ -131,7 +129,7 @@ typedef void(^singleTrackDownloaded)(NSData* trackData);
     [self.lblArtistValue setHidden:YES];
     [self.lblLengthValue setHidden:YES];
     [self.btnChangeParams setHidden:YES];
-    self.backgroundImage.alpha = LoggedOutBackgroundImage_Opacity;
+    self.backgroundImage.alpha = LoggedOutBackgroundImageOpacity;
     self.searchParams.hasChanged = YES;
     NSLog(@"Logged out.");
 }
@@ -292,7 +290,7 @@ typedef void(^singleTrackDownloaded)(NSData* trackData);
 }
 
 - (void)setupLockScreenInfo:(Track*)track {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+    dispatch_async([Utility getGlobalBackgroundQueue], ^{
         
         NSNumber *songDurationInSeconds = [NSNumber numberWithInt:(int)(track.duration / 1000)];
         
@@ -343,7 +341,7 @@ typedef void(^singleTrackDownloaded)(NSData* trackData);
     self.imgArtwork.alpha = 1.0;
     self.btnChangeParams.layer.borderColor = [UIColor blackColor].CGColor;
     
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+    dispatch_async([Utility getGlobalBackgroundQueue], ^{
         NSData *albumArtData = [NSData dataWithContentsOfURL:track.albumArtUrl];
         
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/SCloudRandomizer/MusicSource.h
+++ b/SCloudRandomizer/MusicSource.h
@@ -10,11 +10,13 @@
 
 @interface MusicSource: NSObject
 
+typedef void(^tracksFetchedCompletionHandler)(NSArray* tracks);
+typedef void(^singleTrackFetchedCompletionHandler)(NSDictionary* track);
+
 + (MusicSource*) getInstance;
 - (BOOL)isUserLoggedIn;
-- (void)getTracks:(BOOL)shouldGetTrackInfo shouldPlay:(BOOL)playBool;
-- (void)getTrackInfo:(NSDictionary *)track shouldPlay:(BOOL)play;
+- (void)getRandomTrack:(NSString*)searchKeywords completionHandler:(singleTrackFetchedCompletionHandler)completionHandler;
 - (void)logout;
-- (void)updateLikedState:(BOOL)isSongLiked trackId:(NSString*)trackIdToUpdate;
+- (void)updateLikeState:(BOOL)isSongLiked trackId:(NSString*)trackIdToUpdate;
 
 @end

--- a/SCloudRandomizer/MusicSource.h
+++ b/SCloudRandomizer/MusicSource.h
@@ -1,0 +1,20 @@
+//
+//  MusicSource.h
+//  SCloudRandomizer
+//
+//  Created by Asha Balasubramaniam on 4/29/15.
+//  Copyright (c) 2015 Akshay Bharath. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MusicSource: NSObject
+
++ (MusicSource*) getInstance;
+- (BOOL)isUserLoggedIn;
+- (void)getTracks:(BOOL)shouldGetTrackInfo shouldPlay:(BOOL)playBool;
+- (void)getTrackInfo:(NSDictionary *)track shouldPlay:(BOOL)play;
+- (void)logout;
+- (void)updateLikedState:(BOOL)isSongLiked trackId:(NSString*)trackIdToUpdate;
+
+@end

--- a/SCloudRandomizer/MusicSource.h
+++ b/SCloudRandomizer/MusicSource.h
@@ -7,11 +7,13 @@
 //
 
 #import <Foundation/Foundation.h>
+@class Track;
 
 @interface MusicSource: NSObject
 
+
 typedef void(^tracksFetchedCompletionHandler)(NSArray* tracks);
-typedef void(^singleTrackFetchedCompletionHandler)(NSDictionary* track);
+typedef void(^singleTrackFetchedCompletionHandler)(Track* track);
 
 + (MusicSource*) getInstance;
 - (BOOL)isUserLoggedIn;

--- a/SCloudRandomizer/MusicSource.h
+++ b/SCloudRandomizer/MusicSource.h
@@ -7,10 +7,10 @@
 //
 
 #import <Foundation/Foundation.h>
+
 @class Track;
 
 @interface MusicSource: NSObject
-
 
 typedef void(^tracksFetchedCompletionHandler)(NSArray* tracks);
 typedef void(^singleTrackFetchedCompletionHandler)(Track* track);

--- a/SCloudRandomizer/MusicSource.m
+++ b/SCloudRandomizer/MusicSource.m
@@ -10,20 +10,18 @@
 #import <SCSoundCloud.h>
 #import <SCRequest.h>
 #import "MusicSource.h"
+#import "Track.h"
 
 static MusicSource *instance;
 
 @interface MusicSource ()
-
 - (void)getTracks:(NSString*)searchKeywords completionHandler:(tracksFetchedCompletionHandler)completionHandler;
-
 @end
 
 
 @implementation MusicSource : NSObject
 
-+ (MusicSource*) getInstance
-{
++ (MusicSource*) getInstance {
     if (instance == nil) {
         instance = [[MusicSource alloc] init];
     }
@@ -31,21 +29,19 @@ static MusicSource *instance;
     return instance;
 }
 
-- (BOOL) isUserLoggedIn
-{
+- (BOOL) isUserLoggedIn {
     return [SCSoundCloud account];
 }
 
-- (void)getRandomTrack:(NSString*)searchKeywords completionHandler:(singleTrackFetchedCompletionHandler)completionHandler
-{
+- (void)getRandomTrack:(NSString*)searchKeywords completionHandler:(singleTrackFetchedCompletionHandler)completionHandler {
     [self getTracks:searchKeywords completionHandler:^(NSArray* tracks) {
         int randomSongIndex = arc4random_uniform((uint32_t) tracks.count);
-        completionHandler([tracks objectAtIndex:randomSongIndex]);
+        Track* track = [[Track alloc] initWithData:[tracks objectAtIndex:randomSongIndex] account:[SCSoundCloud account]];
+        completionHandler(track);
     }];
 }
 
-- (void)getTracks:(NSString*)searchKeywords completionHandler:(tracksFetchedCompletionHandler)completionHandler
-{
+- (void)getTracks:(NSString*)searchKeywords completionHandler:(tracksFetchedCompletionHandler)completionHandler {
     SCRequestResponseHandler responseHandler =
     ^(NSURLResponse *response, NSData *data, NSError *error)
     {
@@ -77,18 +73,11 @@ static MusicSource *instance;
              responseHandler:responseHandler];
 }
 
-- (void)getTrackInfo:(NSDictionary *)track
-{
-    
-}
-
-- (void)logout
-{
+- (void)logout {
     [SCSoundCloud removeAccess];
 }
 
-- (void) updateLikeState:(BOOL)isSongLiked trackId:(NSString *)trackIdToUpdate
-{
+- (void) updateLikeState:(BOOL)isSongLiked trackId:(NSString *)trackIdToUpdate {
     NSString *resourceURL = @"https://api.soundcloud.com/me/favorites/";
     NSURL *postURL = [NSURL URLWithString:[resourceURL stringByAppendingString: trackIdToUpdate]];
     

--- a/SCloudRandomizer/MusicSource.m
+++ b/SCloudRandomizer/MusicSource.m
@@ -1,0 +1,74 @@
+//
+//  MusicSource.m
+//  SCloudRandomizer
+//
+//  Created by Asha Balasubramaniam on 4/29/15.
+//  Copyright (c) 2015 Akshay Bharath. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <SCSoundCloud.h>
+#import <SCRequest.h>
+#import "MusicSource.h"
+
+static MusicSource *instance;
+
+@interface MusicSource ()
+
+@end
+
+
+@implementation MusicSource : NSObject
+
++ (MusicSource*) getInstance
+{
+    if (instance == nil) {
+        instance = [[MusicSource alloc] init];
+    }
+    
+    return instance;
+}
+
+- (BOOL) isUserLoggedIn
+{
+    return [SCSoundCloud account];
+}
+
+- (void)getTracks:(BOOL)shouldGetTrackInfo shouldPlay:(BOOL)playBool
+{
+    
+}
+
+- (void)getTrackInfo:(NSDictionary *)track shouldPlay:(BOOL)play
+{
+    
+}
+
+- (void)logout
+{
+    [SCSoundCloud removeAccess];
+}
+
+- (void) updateLikedState:(BOOL)isSongLiked trackId:(NSString *)trackIdToUpdate
+{
+    NSString *resourceURL = @"https://api.soundcloud.com/me/favorites/";
+    NSURL *postURL = [NSURL URLWithString:[resourceURL stringByAppendingString: trackIdToUpdate]];
+    
+    SCRequestMethod requestMethod;
+    
+    if (isSongLiked) {
+        requestMethod = SCRequestMethodPUT;
+    } else {
+        requestMethod = SCRequestMethodDELETE;
+    }
+    
+    [SCRequest performMethod:requestMethod
+            onResource:postURL
+            usingParameters:nil
+            withAccount:[SCSoundCloud account]
+            sendingProgressHandler:nil
+            responseHandler:nil];
+}
+
+
+@end

--- a/SCloudRandomizer/SearchParams.h
+++ b/SCloudRandomizer/SearchParams.h
@@ -11,7 +11,7 @@
 
 @interface SearchParams : NSObject
 
-@property BOOL hasParamsChanged;
+@property BOOL hasChanged;
 @property (strong, nonatomic) NSNumber *lowBpm;
 @property (strong, nonatomic) NSNumber *highBpm;
 @property (strong, nonatomic) NSString *keywords;

--- a/SCloudRandomizer/SearchParams.m
+++ b/SCloudRandomizer/SearchParams.m
@@ -12,7 +12,7 @@
 
 - (id)initWithBool:(BOOL)changed keywords:(NSString *)theKeywords lowBpm:(NSNumber *)lBpm highBpm:(NSNumber *)hBpm
 {
-    self.hasParamsChanged = changed;
+    self.hasChanged = changed;
     self.keywords = theKeywords;
     self.lowBpm = lBpm;
     self.highBpm = hBpm;

--- a/SCloudRandomizer/SearchParamsVC.m
+++ b/SCloudRandomizer/SearchParamsVC.m
@@ -7,6 +7,7 @@
 //
 
 #import "SearchParamsVC.h"
+#import "Utility.h"
 
 @interface SearchParamsVC ()
 
@@ -16,8 +17,7 @@
 
 @implementation SearchParamsVC
 
-- (void)viewDidLoad
-{
+- (void)viewDidLoad {
     [super viewDidLoad];
     
     // Draw border around both buttons
@@ -33,8 +33,7 @@
     [self.view addGestureRecognizer:tap];
 }
 
-- (void)viewWillAppear:(BOOL)animated
-{
+- (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     
     // Create strong local ref to delegate
@@ -46,17 +45,15 @@
     self.txtBpmTo.text = [self.searchParams.highBpm stringValue];
 }
 
-- (void)didReceiveMemoryWarning
-{
+- (void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
 }
 
-- (IBAction)done:(id)sender
-{
+- (IBAction)done:(id)sender {
     [self dismissKeyboard];
     
-    if (![GlobalData stringIsNilOrEmpty:self.txtKeywords.text])
+    if (![Utility stringIsNilOrEmpty:self.txtKeywords.text])
     {
         NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
         self.searchParams.hasChanged = YES;
@@ -74,14 +71,12 @@
     }
 }
 
-- (IBAction)cancel:(id)sender
-{
+- (IBAction)cancel:(id)sender {
     [self dismissKeyboard];
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
-- (void)dismissKeyboard
-{
+- (void)dismissKeyboard {
     [self.txtKeywords resignFirstResponder];
     [self.txtBpmTo resignFirstResponder];
     [self.txtBpmFrom resignFirstResponder];

--- a/SCloudRandomizer/SearchParamsVC.m
+++ b/SCloudRandomizer/SearchParamsVC.m
@@ -59,7 +59,7 @@
     if (![GlobalData stringIsNilOrEmpty:self.txtKeywords.text])
     {
         NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
-        self.searchParams.hasParamsChanged = YES;
+        self.searchParams.hasChanged = YES;
         self.searchParams.keywords = self.txtKeywords.text;
         self.searchParams.lowBpm = [formatter numberFromString:self.txtBpmFrom.text];
         self.searchParams.highBpm = [formatter numberFromString:self.txtBpmTo.text];

--- a/SCloudRandomizer/Track.h
+++ b/SCloudRandomizer/Track.h
@@ -10,7 +10,7 @@
 
 @interface Track : NSObject
 
-@property (nonatomic) NSString *Id;
+@property (nonatomic) NSNumber *Id;
 @property (nonatomic) NSString *streamUrl;
 @property (nonatomic) NSNumber *isLiked;
 @property (nonatomic) NSString *title;

--- a/SCloudRandomizer/Track.h
+++ b/SCloudRandomizer/Track.h
@@ -1,0 +1,32 @@
+//
+//  Track.h
+//  SCloudRandomizer
+//
+//  Created by Asha Balasubramaniam on 4/29/15.
+//  Copyright (c) 2015 Akshay Bharath. All rights reserved.
+//
+
+@class SCAccount;
+
+@interface Track : NSObject
+
+@property (nonatomic) NSString *Id;
+@property (nonatomic) NSString *streamUrl;
+@property (nonatomic) NSNumber *isLiked;
+@property (nonatomic) NSString *title;
+@property (nonatomic) NSString *artist;
+@property (nonatomic) long duration;
+@property (nonatomic) NSURL *albumArtUrl;
+@property (nonatomic) SCAccount *account;
+@property (nonatomic) long likes;
+@property (nonatomic) long plays;
+@property (nonatomic) NSString *uploadedOn;
+@property (nonatomic) NSString *songDescription;
+@property (nonatomic) NSString *tags;
+
+typedef void(^trackDownloaded)(NSData* trackData);
+
+- (id)initWithData:(NSDictionary*)data account:(SCAccount *) account;
+- (void) download:(trackDownloaded)completionHandler;
+
+@end

--- a/SCloudRandomizer/Track.m
+++ b/SCloudRandomizer/Track.m
@@ -1,0 +1,74 @@
+//
+//  Track.m
+//  SCloudRandomizer
+//
+//  Created by Asha Balasubramaniam on 4/29/15.
+//  Copyright (c) 2015 Akshay Bharath. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <SCRequest.h>
+#import <SCAccount.h>
+#import "Track.h"
+
+@implementation Track : NSObject
+
+-(id) initWithData:(NSDictionary *)data account:(SCAccount *)account {
+    self.Id = [data objectForKey:@"id"];
+    self.title = [data objectForKey:@"title"];
+    self.artist = [[data objectForKey:@"user"] objectForKey:@"username"];
+    self.duration = [[data objectForKey:@"duration"] longValue];
+    
+    NSString *albumArtUrlString = nil;
+    id albumArt = [data objectForKey:@"artwork_url"];
+    if (albumArt == [NSNull null]) {
+        albumArtUrlString = [[[data objectForKey:@"user"] objectForKey:@"avatar_url"] stringByReplacingOccurrencesOfString:@"-large" withString:@"-t300x300"];
+    }
+    else {
+        albumArtUrlString = [(NSString *)albumArt stringByReplacingOccurrencesOfString:@"-large" withString:@"-t300x300"];
+    }
+    self.albumArtUrl = [NSURL URLWithString:albumArtUrlString];
+    
+    self.streamUrl = [data objectForKey:@"stream_url"];
+    
+    // ToDo - Figure out when this happens and fix
+    if (self.streamUrl == nil) {
+        NSException* noStreamUrlException = [NSException
+                                    exceptionWithName:@"No Stream Url associated with track"
+                                    reason:@"Stream Url not Found on System"
+                                    userInfo:nil];
+        @throw noStreamUrlException;
+    }
+    
+    self.account = account;
+    
+    self.isLiked = [data objectForKey:@"user_favorite"];
+    
+    self.likes = [[data objectForKey:@"favoritings_count"] longValue];
+    
+    self.plays = [[data objectForKey:@"playback_count"] longValue];
+    
+    self.uploadedOn = [data objectForKey:@"created_at"];
+    
+    self.songDescription = [data objectForKey:@"description"];
+    
+    return self;
+}
+
+-(void) download:(trackDownloaded)completionHandler {
+
+    SCRequestResponseHandler responseHandler =
+    ^(NSURLResponse *response, NSData *data, NSError *error) {
+        // ToDo: Correct way of invoking a callback?
+        completionHandler(data);
+    };
+    
+    [SCRequest performMethod:SCRequestMethodGET
+                  onResource:[NSURL URLWithString:self.streamUrl]
+             usingParameters:nil
+                 withAccount:self.account
+      sendingProgressHandler:nil
+             responseHandler:responseHandler];
+}
+
+@end

--- a/SCloudRandomizer/TrackInfoVC.m
+++ b/SCloudRandomizer/TrackInfoVC.m
@@ -7,6 +7,7 @@
 //
 
 #import "TrackInfoVC.h"
+#import "Track.h"
 
 @interface TrackInfoVC ()
 
@@ -29,29 +30,24 @@
     [super viewWillAppear:animated];
     
     id<MainVCDelegate> strongDelegate = self.delegate;
-    NSDictionary *track = [strongDelegate getCurrentTrack];
+    Track *track = [strongDelegate getCurrentTrack];
     
-    long likes = [[track objectForKey:@"favoritings_count"] longValue];
-    long plays = [[track objectForKey:@"playback_count"] longValue];
-    NSString *uploaded = [track objectForKey:@"created_at"];
-    
-    NSString *desc = [track objectForKey:@"description"];
-    if ([desc length] == 0)
-    {
-        desc = @"No description";
-    }
-    [self.songDescription setText:desc];
 
-    [self.songTitle setText:[track objectForKey:@"title"]];
+    NSString* songDescription = track.songDescription;
+    if ([songDescription length] == 0) {
+        songDescription = @"No description";
+    }
     
-    [self.artist setText:[[track objectForKey:@"user"] objectForKey:@"username"]];
-    [self.likes setText: [[NSNumber numberWithLong:likes] stringValue]];
-    [self.numOfPlays setText: [[NSNumber numberWithLong:plays] stringValue]];
+    [self.songDescription setText:songDescription];
+    [self.songTitle setText:track.title];
+    [self.artist setText:track.artist];
+    [self.likes setText: [[NSNumber numberWithLong:track.likes] stringValue]];
+    [self.numOfPlays setText: [[NSNumber numberWithLong:track.plays] stringValue]];
     
     [self.uploadedTime
-      setText: [NSString stringWithFormat: @"Uploaded at %@", [uploaded substringToIndex:10]]];
+      setText: [NSString stringWithFormat: @"Uploaded on %@", [track.uploadedOn substringToIndex:10]]];
     
-    NSString* tags = [track objectForKey:@"tag_list"];
+    NSString* tags = track.tags;
     if ([tags length] == 0) {
         [self.tags setText:@"None"];
     } else {

--- a/SCloudRandomizer/Utility.h
+++ b/SCloudRandomizer/Utility.h
@@ -9,5 +9,7 @@
 @interface Utility : NSObject
 
 + (NSString *)convertFromMilliseconds:(long)duration;
++ (dispatch_queue_t)getGlobalBackgroundQueue;
++ (BOOL)stringIsNilOrEmpty:(NSString*)aString;
 
 @end

--- a/SCloudRandomizer/Utility.h
+++ b/SCloudRandomizer/Utility.h
@@ -1,0 +1,13 @@
+//
+//  Utility.h
+//  SCloudRandomizer
+//
+//  Created by Asha Balasubramaniam on 4/30/15.
+//  Copyright (c) 2015 Akshay Bharath. All rights reserved.
+//
+
+@interface Utility : NSObject
+
++ (NSString *)convertFromMilliseconds:(long)duration;
+
+@end

--- a/SCloudRandomizer/Utility.m
+++ b/SCloudRandomizer/Utility.m
@@ -11,8 +11,7 @@
 
 @implementation Utility
 
-+ (NSString *)convertFromMilliseconds:(long)duration
-{
++ (NSString *)convertFromMilliseconds:(long)duration {
     NSInteger minutes = floor(duration / 60000);
     NSInteger seconds = ((duration % 60000) / 1000);
     NSString *formatted = nil;
@@ -24,6 +23,14 @@
     }
     
     return formatted;
+}
+
++ (dispatch_queue_t)getGlobalBackgroundQueue {
+    return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0);
+}
+
++ (BOOL)stringIsNilOrEmpty:(NSString*)aString {
+    return !(aString && aString.length);
 }
 
 @end

--- a/SCloudRandomizer/Utility.m
+++ b/SCloudRandomizer/Utility.m
@@ -16,12 +16,10 @@
     NSInteger minutes = floor(duration / 60000);
     NSInteger seconds = ((duration % 60000) / 1000);
     NSString *formatted = nil;
-    if (seconds < 10)
-    {
+    if (seconds < 10) {
         formatted = [NSString stringWithFormat:@"%ld:0%ld", (long)minutes, (long)seconds];
     }
-    else
-    {
+    else {
         formatted = [NSString stringWithFormat:@"%ld:%ld", (long)minutes, (long)seconds];
     }
     

--- a/SCloudRandomizer/Utility.m
+++ b/SCloudRandomizer/Utility.m
@@ -1,0 +1,31 @@
+//
+//  Utility.m
+//  SCloudRandomizer
+//
+//  Created by Asha Balasubramaniam on 4/30/15.
+//  Copyright (c) 2015 Akshay Bharath. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Utility.h"
+
+@implementation Utility
+
++ (NSString *)convertFromMilliseconds:(long)duration
+{
+    NSInteger minutes = floor(duration / 60000);
+    NSInteger seconds = ((duration % 60000) / 1000);
+    NSString *formatted = nil;
+    if (seconds < 10)
+    {
+        formatted = [NSString stringWithFormat:@"%ld:0%ld", (long)minutes, (long)seconds];
+    }
+    else
+    {
+        formatted = [NSString stringWithFormat:@"%ld:%ld", (long)minutes, (long)seconds];
+    }
+    
+    return formatted;
+}
+
+@end


### PR DESCRIPTION
### Refactor `MainViewController`
- Moved most of the Sound cloud specific code out of this controller into separate model and utility classes
- The MainViewController now talks to `MusicSource` to get a track and then play it
### Models
- `MusicSource` contains the logic to fetch a random track from SoundCloud each time the user launches the app and/or clicks next on the player
- `Track` encapsulates information about a single track
### Helper classes
- Currently we only have a single `Utility` class that has a helper method
### Other changes
- Changes formatting of methods so that function opening braces are on the same line as the function name
- While testing I did not encounter a problem where a stream url can be null so throwing an exception when that happens to catch that problem
